### PR TITLE
fix: show real API error messages instead of bare HTTP status

### DIFF
--- a/electron-ui/electron/preload.js
+++ b/electron-ui/electron/preload.js
@@ -1,5 +1,26 @@
 const { contextBridge, ipcRenderer } = require('electron')
 
+/**
+ * Extract a human-readable error message from a failed response.
+ * FastAPI returns errors as JSON with a "detail" field (string or array).
+ * Falls back to "HTTP {status}" if the body isn't JSON or has no detail.
+ */
+async function getErrorMessage(response) {
+    try {
+        const data = await response.json()
+        if (data && data.detail !== undefined) {
+            if (Array.isArray(data.detail)) {
+                // FastAPI validation errors: array of {loc, msg, type}
+                return data.detail.map((d) => d.msg || JSON.stringify(d)).join('; ')
+            }
+            return String(data.detail)
+        }
+    } catch (_) {
+        // Response wasn't JSON — fall through
+    }
+    return `HTTP ${response.status}`
+}
+
 contextBridge.exposeInMainWorld('clippy', {
 
     chat: async (message, conversationId) => {
@@ -14,7 +35,7 @@ contextBridge.exposeInMainWorld('clippy', {
             })
         })
         
-        if (!response.ok) throw new Error(`HTTP ${response.status}`)
+        if (!response.ok) throw new Error(await getErrorMessage(response))
         return response.json()
     },
 
@@ -27,7 +48,7 @@ contextBridge.exposeInMainWorld('clippy', {
                 conversation_id: conversationId,
             }),
         })
-        if (!response.ok) throw new Error(`HTTP ${response.status}`)
+        if (!response.ok) throw new Error(await getErrorMessage(response))
         if (!response.body) throw new Error('No response body')
 
         const reader = response.body.getReader()
@@ -53,7 +74,7 @@ contextBridge.exposeInMainWorld('clippy', {
 
     getName: async () => {
         const response = await fetch('http://localhost:8000/user/name')
-        if (!response.ok) throw new Error(`HTTP ${response.status}`)
+        if (!response.ok) throw new Error(await getErrorMessage(response))
         return response.json()
     },
 
@@ -63,13 +84,13 @@ contextBridge.exposeInMainWorld('clippy', {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ name }),
         })
-        if (!response.ok) throw new Error(`HTTP ${response.status}`)
+        if (!response.ok) throw new Error(await getErrorMessage(response))
         return response.json()
     },
 
     getProfile: async () => {
         const response = await fetch('http://localhost:8000/user/profile')
-        if (!response.ok) throw new Error(`HTTP ${response.status}`)
+        if (!response.ok) throw new Error(await getErrorMessage(response))
         return response.json()
     },
 
@@ -79,13 +100,13 @@ contextBridge.exposeInMainWorld('clippy', {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         })
-        if (!response.ok) throw new Error(`HTTP ${response.status}`)
+        if (!response.ok) throw new Error(await getErrorMessage(response))
         return response.json()
     },
 
     getPrivacySettings: async () => {
         const response = await fetch('http://localhost:8000/settings/privacy')
-        if (!response.ok) throw new Error(`HTTP ${response.status}`)
+        if (!response.ok) throw new Error(await getErrorMessage(response))
         return response.json()
     },
 
@@ -95,20 +116,20 @@ contextBridge.exposeInMainWorld('clippy', {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ enabled }),
         })
-        if (!response.ok) throw new Error(`HTTP ${response.status}`)
+        if (!response.ok) throw new Error(await getErrorMessage(response))
         return response.json()
     },
 
     listConversations: async () => {
         const response = await fetch('http://localhost:8000/conversations')
-        if (!response.ok) throw new Error(`HTTP ${response.status}`)
+        if (!response.ok) throw new Error(await getErrorMessage(response))
         return response.json()
     },
 
     searchConversations: async (query, limit = 20) => {
         const params = new URLSearchParams({ q: query || '', limit: String(limit) })
         const response = await fetch(`http://localhost:8000/conversations/search?${params}`)
-        if (!response.ok) throw new Error(`HTTP ${response.status}`)
+        if (!response.ok) throw new Error(await getErrorMessage(response))
         return response.json()
     },
 
@@ -116,7 +137,7 @@ contextBridge.exposeInMainWorld('clippy', {
         const response = await fetch(
             `http://localhost:8000/conversations/${encodeURIComponent(conversationId)}`
         )
-        if (!response.ok) throw new Error(`HTTP ${response.status}`)
+        if (!response.ok) throw new Error(await getErrorMessage(response))
         return response.json()
     },
 


### PR DESCRIPTION
## Summary

This PR resolves #2 by showing the actual API error messages in the UI instead of bare 'HTTP 400' status codes.

## Changes

- Added  helper function that:
  - Parses FastAPI JSON error responses with  field
  - Handles both string and array (validation) error formats
  - Falls back to  for non-JSON error bodies
- Replaced all 11 occurrences of bare  throws with the helper

## Verification

- [x] Shared helper parses  (string or array) when present
- [x] All fetch wrappers in  use it
- [x] Non-JSON error bodies fall back gracefully