### PR TITLE
Add a Copy button to Clippy's replies

### DIFF
--- a/electron-ui/src/index.html
+++ b/electron-ui/src/index.html
@@ -759,6 +759,24 @@
       padding-top: 8px;
     }
 
+    .copy-reply {
+      align-self: flex-start;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 2px 0;
+      background: transparent;
+      border: none;
+      color: var(--muted);
+      font-family: inherit;
+      font-size: 12px;
+      font-weight: 550;
+      cursor: pointer;
+      text-align: left;
+    }
+
+    .copy-reply:hover { color: var(--text); }
+
     .message-body {
       line-height: 1.55;
       word-break: break-word;
@@ -1636,8 +1654,35 @@
       let rawContent = content || ''
       if (rawContent) setMessageMarkdown(messageBody, rawContent)
 
+      const copyBtn = document.createElement('button')
+      copyBtn.type = 'button'
+      copyBtn.className = 'copy-reply'
+      copyBtn.textContent = 'Copy'
+      copyBtn.style.display = rawContent ? '' : 'none'
+
+      let copyResetTimer = null
+      copyBtn.addEventListener('click', async () => {
+        if (!rawContent) return
+        try {
+          await navigator.clipboard.writeText(rawContent)
+        } catch {
+          return
+        }
+        copyBtn.textContent = 'Copied'
+        if (copyResetTimer) clearTimeout(copyResetTimer)
+        copyResetTimer = setTimeout(() => {
+          copyBtn.textContent = 'Copy'
+          copyResetTimer = null
+        }, 1500)
+      })
+
+      function updateCopyVisibility() {
+        copyBtn.style.display = rawContent ? '' : 'none'
+      }
+
       root.appendChild(thinkBlock)
       root.appendChild(messageBody)
+      root.appendChild(copyBtn)
 
       if (!thinking && !pending) {
         thinkBlock.style.display = 'none'
@@ -1658,12 +1703,14 @@
         appendContent(delta) {
           rawContent += delta || ''
           setMessageMarkdown(messageBody, rawContent)
+          updateCopyVisibility()
           messages.scrollTop = messages.scrollHeight
         },
         resetContent() {
           rawContent = ''
           messageBody.classList.remove('md')
           messageBody.innerHTML = ''
+          updateCopyVisibility()
         },
         setStatus(text) {
           thinkBlock.style.display = ''
@@ -1677,6 +1724,7 @@
             thinkBlock.style.display = 'none'
           }
           if (rawContent) setMessageMarkdown(messageBody, rawContent)
+          updateCopyVisibility()
         },
         fail(message) {
           thinkBlock.classList.remove('is-pending')
@@ -1685,6 +1733,7 @@
           messageBody.classList.remove('md')
           messageBody.textContent = message
           messageBody.style.color = 'var(--danger)'
+          updateCopyVisibility()
         },
       }
     }


### PR DESCRIPTION
Fixes #21

## What changed

- Added a `copy-reply` button inside `createBotReplyShell` in `electron-ui/src/index.html`, appended to the shell `root` under the message body, so both streamed replies and replies replayed from saved conversations get one automatically.
- The click handler reads `rawContent` at click time (not captured at shell creation, since `appendContent`/`resetContent` mutate it) and copies it with `await navigator.clipboard.writeText(...)`, so the original markdown survives intact when pasted elsewhere.
- On success the label switches to "Copied" for 1.5 s and then restores; repeated clicks clear the previous timer so the label never gets stuck.
- The button is hidden whenever `rawContent` is empty (pending/streaming start, `resetContent`, `fail`), so an empty string can never be copied. Visibility is refreshed from `appendContent`, `resetContent`, `finalize`, and `fail`.
- Styling follows the existing `.think-toggle` rules (same font size/weight, `var(--muted)` with `var(--text)` on hover, transparent background) via a new `.copy-reply` CSS class, no inline styles beyond the show/hide toggle and no new dependencies.
- Scoped to assistant replies only; user messages, thinking-block toggle, and streaming behaviour are untouched.

## How verified

- Extracted the inline script from `index.html` and confirmed it still parses.
- Traced both entry points: the streaming path (`createBotReplyShell({ pending: true })`) starts with the button hidden until content arrives, and `addMessage` replaying saved conversations passes `content` so the button is visible immediately.
- No build step exists for the renderer (`npm start` runs Electron directly on `src/index.html`).