### PR TITLE
Add app version display to Settings About section

### DIFF
--- a/electron-ui/electron/main.js
+++ b/electron-ui/electron/main.js
@@ -1377,6 +1377,7 @@ ipcMain.handle('open-external', (_event, url) => {
 
 ipcMain.handle('get-api-base', async () => apiUrl())
 ipcMain.handle('get-update-check', () => readDesktopSettings().updateCheckEnabled)
+ipcMain.handle('get-app-version', () => app.getVersion())
 ipcMain.handle('set-update-check', (_event, enabled) => setUpdateCheckEnabled(enabled))
 
 ipcMain.handle('get-hardware-check', async () => getHardwareCheck())

--- a/electron-ui/electron/preload.js
+++ b/electron-ui/electron/preload.js
@@ -169,6 +169,8 @@ contextBridge.exposeInMainWorld('clippy', {
 
     setUpdateCheckEnabled: (enabled) => ipcRenderer.invoke('set-update-check', Boolean(enabled)),
 
+    getAppVersion: () => ipcRenderer.invoke('get-app-version'),
+
     toggleCapture: () => ipcRenderer.invoke('toggle-capture'),
 
     getCaptureStatus: () => ipcRenderer.invoke('get-capture-status'),

--- a/electron-ui/src/index.html
+++ b/electron-ui/src/index.html
@@ -1502,6 +1502,21 @@
           <span id="updates-status" class="settings-status"></span>
         </div>
       </section>
+
+      <section class="settings-section" id="about-section">
+        <h2>About</h2>
+        <p class="settings-hint">
+          The version of Clippy Vision currently installed on this machine.
+        </p>
+        <div class="privacy-list">
+          <div class="privacy-row">
+            <div class="privacy-row-text">
+              <strong>Clippy Vision</strong>
+              <span id="about-version">Version unavailable</span>
+            </div>
+          </div>
+        </div>
+      </section>
     </div>
   </div>
 
@@ -1558,6 +1573,7 @@
     const profileStatus = document.getElementById('profile-status')
     const updateCheckToggle = document.getElementById('update-check-toggle')
     const updatesStatus = document.getElementById('updates-status')
+    const aboutVersion = document.getElementById('about-version')
 
     let isLoading = false
     // In-flight bot reply kept across conversation switches
@@ -2416,6 +2432,15 @@
       }
     }
 
+    async function loadAppVersion() {
+      try {
+        const version = await window.clippy.getAppVersion()
+        aboutVersion.textContent = version ? `Version ${version}` : 'Version unavailable'
+      } catch (error) {
+        aboutVersion.textContent = 'Version unavailable'
+      }
+    }
+
     async function saveUpdateCheck() {
       const desired = updateCheckToggle.checked
       updateCheckToggle.disabled = true
@@ -2433,6 +2458,7 @@
 
     async function loadSettings() {
       loadUpdateCheck()
+      loadAppVersion()
       setStatus(profileStatus, 'Loading…', null)
       try {
         const profile = await window.clippy.getProfile()


### PR DESCRIPTION
Closes #22

## Changes
- Added a new IPC handler `get-app-version` in `main.js` that returns the installed app version via `app.getVersion()`
- Exposed it to the renderer through `preload.js` as `getAppVersion()`
- Added a new "About" section in Settings (`index.html`) that displays the installed version, fetched via IPC (not hardcoded)

## Testing
Verified via code review that:
- The version is sourced from `app.getVersion()` over IPC, not hardcoded in HTML
- The new section follows the existing settings-section styling pattern
- No new npm dependencies were added

Note: Was unable to fully run the app locally due to hardware requirements for the AI setup step (unrelated to this change), so testing was done via careful code review against the existing patterns in the codebase (e.g. `get-update-check` / `getUpdateCheckEnabled`). Happy to make any adjustments needed after review.