### PR TITLE
Fix Shift+Enter to insert a newline in the chat composer

### DIFF
--- a/electron-ui/src/index.html
+++ b/electron-ui/src/index.html
@@ -891,7 +891,7 @@
 
     #input-row {
       display: flex;
-      align-items: center;
+      align-items: flex-end;
       padding: 16px;
       gap: 10px;
       background: var(--panel);
@@ -907,7 +907,12 @@
       color: var(--text);
       font-size: 14px;
       font-family: inherit;
+      line-height: 1.45;
       outline: none;
+      resize: none;
+      min-height: 40px;
+      max-height: 160px;
+      overflow-y: auto;
     }
 
     #input-box:focus { border-color: var(--accent); }
@@ -1395,7 +1400,7 @@
         <div id="messages"></div>
 
         <div id="input-row">
-          <input id="input-box" type="text" placeholder="Ask Clippy..." maxlength="4000" />
+          <textarea id="input-box" rows="1" placeholder="Ask Clippy..." maxlength="4000"></textarea>
           <span id="input-char-count" class="char-count" aria-live="polite"></span>
           <button id="send-btn">Send</button>
         </div>
@@ -1827,6 +1832,7 @@
       conversationId = crypto.randomUUID()
       messages.innerHTML = ''
       inputBox.value = ''
+      inputBox.style.height = 'auto'
       setChatMode('welcome')
       highlightActiveConversation()
       closeDrawer()
@@ -2108,7 +2114,7 @@
       isLoading = true
       addMessage(text, 'user')
       source.value = ''
-      if (fromWelcome) welcomeInput.style.height = 'auto'
+      source.style.height = 'auto'
       sendBtn.disabled = true
       welcomeSend.disabled = true
 
@@ -2286,7 +2292,10 @@
     newChatBtn.addEventListener('click', resetConversation)
     sendBtn.addEventListener('click', () => send(false))
     inputBox.addEventListener('keydown', e => {
-      if (e.key === 'Enter') send(false)
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault()
+        send(false)
+      }
     })
 
     welcomeSend.addEventListener('click', () => send(true))
@@ -2302,6 +2311,8 @@
       updateCharCount(welcomeInput, welcomeCharCount)
     })
     inputBox.addEventListener('input', () => {
+      inputBox.style.height = 'auto'
+      inputBox.style.height = Math.min(inputBox.scrollHeight, 160) + 'px'
       updateCharCount(inputBox, inputCharCount)
     })
 


### PR DESCRIPTION
Closes #35.

## What changed

The main chat composer was a single-line `<input>` that sent on every Enter, so Shift+Enter could not insert a newline. It is now a `<textarea rows="1">` with the same auto-grow behavior as the welcome composer (grows with content, capped at 160px, `resize: none`), and its `keydown` handler only sends on plain Enter — `e.key === 'Enter' && !e.shiftKey` with `preventDefault()`, mirroring `welcomeInput`.

Kept the two composers consistent on reset as well: `send()` collapses the height of whichever composer was the source, and `resetConversation()` resets the main composer's height along with its value.

## How I verified

Loaded the page in a jsdom harness and drove it with real `KeyboardEvent`s:

- Shift+Enter on either composer keeps the text and does not cancel the default action, so the newline is inserted
- plain Enter clears the composer (the send path ran) and cancels the default action, so no stray newline is left behind
- the `input` listener sets an explicit pixel height as the box grows

All 11 assertions pass, and the welcome composer's behavior is unchanged.
