### PR TITLE
feat: show conversation timestamps

### DIFF
--- a/electron-ui/src/index.html
+++ b/electron-ui/src/index.html
@@ -561,17 +561,37 @@
       font-weight: 500;
       line-height: 1.3;
       cursor: pointer;
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      justify-content: center;
       overflow: hidden;
       word-break: break-word;
       transition: color 0.12s ease;
     }
 
+    .conv-item-title {
+      width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .conv-item-time {
+      margin-top: 2px;
+      color: var(--muted);
+      font-size: 10.5px;
+      font-weight: 400;
+      line-height: 1.2;
+    }
+
     .conv-item-row.active .conv-item {
       color: var(--accent-hover);
       font-weight: 600;
+    }
+
+    .conv-item-row.active .conv-item-time {
+      font-weight: 400;
     }
 
     .conv-item-delete {
@@ -2401,6 +2421,29 @@
       return new Date(d.getFullYear(), d.getMonth(), d.getDate())
     }
 
+    function formatConversationTime(timestamp) {
+      if (!timestamp) return ''
+
+      const date = new Date(timestamp * 1000)
+      const today = startOfDay(new Date())
+      const thatDay = startOfDay(date)
+      const diffDays = Math.round((today - thatDay) / 86400000)
+
+      if (diffDays === 0) {
+        return date.toLocaleTimeString('en-US', {
+          hour: 'numeric',
+          minute: '2-digit',
+        })
+      }
+
+      return date.toLocaleString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      })
+    }
+
     function getTimeBucket(timestamp) {
       const date = new Date((timestamp || 0) * 1000)
       const today = startOfDay(new Date())
@@ -2470,8 +2513,20 @@
       const btn = document.createElement('button')
       btn.type = 'button'
       btn.className = 'conv-item'
-      btn.textContent = c.title || c.conversation_id
-      btn.title = c.title || c.conversation_id
+
+      const title = c.title || c.conversation_id
+
+      const titleEl = document.createElement('span')
+      titleEl.className = 'conv-item-title'
+      titleEl.textContent = title
+
+      const timeEl = document.createElement('span')
+      timeEl.className = 'conv-item-time'
+      timeEl.textContent = formatConversationTime(c.last_timestamp)
+
+      btn.appendChild(titleEl)
+      btn.appendChild(timeEl)
+      btn.title = title
       btn.addEventListener('click', () => loadConversation(c.conversation_id))
 
       const del = document.createElement('button')

--- a/electron-ui/src/index.html
+++ b/electron-ui/src/index.html
@@ -2436,12 +2436,18 @@
         })
       }
 
-      return date.toLocaleString('en-US', {
+      const options = {
         month: 'short',
         day: 'numeric',
         hour: 'numeric',
         minute: '2-digit',
-      })
+      }
+
+      if (date.getFullYear() !== today.getFullYear()) {
+        options.year = 'numeric'
+      }
+
+      return date.toLocaleString('en-US', options)
     }
 
     function getTimeBucket(timestamp) {


### PR DESCRIPTION
## Summary

- Show the last conversation timestamp in conversation rows.
- Display the time for conversations from today and a short date/time for older conversations.
- Apply the timestamp display to both the normal conversation list and search results.
- Keep long conversation titles readable in the narrow sidebar with ellipsis.

## Testing

- `git diff --check` passes.
- Verified the change is limited to `electron-ui/src/index.html`.
- Full Electron UI testing was not completed because the local setup requires the Ollama `qwen3:8b` model download (~4.7 GB).

Closes #37