### PR TITLE
test: add MCP stdio smoke coverage

### DIFF
--- a/agent/retrieval.py
+++ b/agent/retrieval.py
@@ -309,6 +309,17 @@ def _extract_where_fragment(sql: str) -> str | None:
 def search_sessions(question: str) -> str:
     """Search session summaries. Best for: broad time windows, daily/weekly
     overviews, project topics, what-did-I-work-on questions."""
+    available = conn.execute(
+        "SELECT 1 FROM sessions WHERE summary IS NOT NULL AND summary != '' LIMIT 1"
+    ).fetchone()
+    if available is None:
+        return (
+            "search_sessions: no matching session summaries found.\n"
+            "Sessions store broad topic summaries — if you need specific "
+            "message text, OCR content, URLs, or app-level detail, "
+            "call search_events."
+        )
+
     now_ts  = int(time.time())
     now_str = time.strftime("%A %B %d, %Y at %H:%M (local time)")
     user_content = f"Current timestamp: {now_ts} ({now_str})\n\nQuestion: {question}"

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from contextlib import redirect_stdout
 
 # Make sure both the project root and core/ are importable
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -8,16 +9,22 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "age
 
 from mcp.server.fastmcp import FastMCP
 
-from agent.memory import (
-    delete_note,
-    fetch_cluster,
-    recall_memory,
-    save_identity,
-    save_note,
-)
-from agent.retrieval import search_events, search_sessions
+with redirect_stdout(sys.stderr):
+    from agent.memory import (
+        delete_note,
+        fetch_cluster,
+        recall_memory,
+        save_identity,
+        save_note,
+    )
+    from agent.retrieval import search_events, search_sessions
 
 mcp = FastMCP("Clippy-Vision MCP")
+
+
+def _call_tool(function, *args, **kwargs):
+    with redirect_stdout(sys.stderr):
+        return function(*args, **kwargs)
 
 
 @mcp.tool()
@@ -27,7 +34,7 @@ def search_sessions_tool(question: str) -> str:
     what-did-I-work-on questions, project topics, task recaps.
     Returns paragraph summaries — NOT granular event detail.
     If the result says the info isn't there, call search_events_tool next."""
-    return search_sessions(question)
+    return _call_tool(search_sessions, question)
 
 @mcp.tool()
 def search_events_tool(question: str) -> str:
@@ -36,20 +43,20 @@ def search_events_tool(question: str) -> str:
     app usage, WhatsApp/email content, fine-grained timestamps, copy-paste history.
     Returns raw event rows with screen/OCR data.
     If the result says the info isn't there, call search_sessions_tool next."""
-    return search_events(question)
+    return _call_tool(search_events, question)
 
 @mcp.tool()
 def recall_memory_tool() -> str:
     """List all long-term memory clusters with labels and descriptions.
     Use when the user asks what you know about them, or before fetching a specific cluster."""
-    return recall_memory()
+    return _call_tool(recall_memory)
 
 @mcp.tool()
 def fetch_cluster_tool(label: str) -> str:
     """Get all facts stored in a named memory cluster.
     Use after recall_memory_tool to get the full content of a specific topic.
     Pass the cluster label exactly as returned by recall_memory_tool."""
-    return fetch_cluster(label)
+    return _call_tool(fetch_cluster, label)
 
 @mcp.tool()
 def save_identity_tool(field: str, op: str, value: str = "", items: list[str] = None) -> str:
@@ -58,19 +65,19 @@ def save_identity_tool(field: str, op: str, value: str = "", items: list[str] = 
     op='add_items' with items=[] for adding to a list (hobbies, skills).
     op='override' only when the user explicitly corrects a previous fact.
     op='remove_items' with items=[] to remove from a list."""
-    return save_identity(field=field, value=value, op=op, items=items)
+    return _call_tool(save_identity, field=field, value=value, op=op, items=items)
 
 @mcp.tool()
 def save_note_tool(note: str) -> str:
     """Save a free-form note or reminder the user wants remembered."""
-    return save_note(note)
+    return _call_tool(save_note, note)
 @mcp.tool()
 
 def delete_note_tool(note_text: str) -> str:
     """Delete a note or memory fact the user wants forgotten.
     Use when the user says 'forget', 'delete', 'remove', or 'don't remember that'.
     Matches by substring — pass the key phrase or exact text from the note."""
-    return delete_note(note_text)
+    return _call_tool(delete_note, note_text)
 
 if __name__ == "__main__":
     mcp.run(transport="stdio")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+except ImportError:
+    ClientSession = None
+    StdioServerParameters = None
+    stdio_client = None
+
+
+@unittest.skipIf(ClientSession is None, "mcp package is not installed")
+class McpServerSmokeTests(unittest.IsolatedAsyncioTestCase):
+    """PowerShell: `$env:PYTHONPATH=(Get-Location).Path; python -m unittest tests.test_mcp_server`."""
+
+    async def test_stdio_server_lists_and_calls_read_tools(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory(prefix="clippy-mcp-") as data_dir:
+            env = os.environ.copy()
+            env["PYTHONPATH"] = str(root)
+            env["CLIPPY_DATA_DIR"] = data_dir
+            parameters = StdioServerParameters(
+                command=sys.executable,
+                args=[str(root / "mcp_server.py")],
+                env=env,
+            )
+
+            async with stdio_client(parameters) as (read_stream, write_stream):
+                async with ClientSession(read_stream, write_stream) as session:
+                    await session.initialize()
+                    listed = await session.list_tools()
+                    tool_names = {tool.name for tool in listed.tools}
+                    self.assertIn("search_sessions_tool", tool_names)
+                    self.assertIn("recall_memory_tool", tool_names)
+
+                    search = await session.call_tool(
+                        "search_sessions_tool",
+                        {"question": "What did I work on today?"},
+                    )
+                    self.assertFalse(search.isError, search.content)
+                    self.assertTrue(search.content)
+                    self.assertIn("search_sessions:", search.content[0].text)
+
+                    recall = await session.call_tool("recall_memory_tool", {})
+                    self.assertFalse(recall.isError, recall.content)
+                    self.assertEqual(recall.content[0].text, "No memory clusters yet.")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -36,8 +36,18 @@ class McpServerSmokeTests(unittest.IsolatedAsyncioTestCase):
                     await session.initialize()
                     listed = await session.list_tools()
                     tool_names = {tool.name for tool in listed.tools}
-                    self.assertIn("search_sessions_tool", tool_names)
-                    self.assertIn("recall_memory_tool", tool_names)
+                    self.assertEqual(
+                        {
+                            "search_sessions_tool",
+                            "search_events_tool",
+                            "recall_memory_tool",
+                            "fetch_cluster_tool",
+                            "save_identity_tool",
+                            "save_note_tool",
+                            "delete_note_tool",
+                        },
+                        tool_names,
+                    )
 
                     search = await session.call_tool(
                         "search_sessions_tool",


### PR DESCRIPTION
## Summary
- exercise initialize, tool discovery, search, and recall through a real stdio client
- redirect tool diagnostics away from protocol stdout
- avoid requiring Ollama when an empty database has no summaries

## Validation
- python -m unittest tests.test_mcp_server -v
- uvx ruff check mcp_server.py agent/retrieval.py tests/test_mcp_server.py

Closes #48