### PR TITLE
feat(api): add paginated timeline sessions endpoint

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -39,6 +39,7 @@ from core.storage import (
     export_data,
     get_data_stats,
     get_user_name,
+    list_timeline_sessions,
     set_user_name,
 )
 
@@ -348,6 +349,25 @@ def screenshot_file(filename: str):
         raise HTTPException(status_code=404, detail="Screenshot not found.")
     return FileResponse(candidate, media_type="image/jpeg")
 
+
+
+@app.get("/timeline/sessions")
+def timeline_sessions(
+    since: float | None = None,
+    until: float | None = None,
+    limit: int = Query(40, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+):
+    return {
+        "sessions": list_timeline_sessions(
+            since=since,
+            until=until,
+            limit=limit,
+            offset=offset,
+        ),
+        "limit": limit,
+        "offset": offset,
+    }
 
 
 @app.get("/conversations")

--- a/core/storage.py
+++ b/core/storage.py
@@ -417,6 +417,51 @@ def store_summary(summary: dict, vision_enriched: bool = False, embedding: list 
     )
     conn.commit()
 
+
+def list_timeline_sessions(
+    since: float | None = None,
+    until: float | None = None,
+    limit: int = 40,
+    offset: int = 0,
+) -> list[dict]:
+    """Return a page of captured sessions that overlaps the requested window."""
+    if since is not None and until is not None and since >= until:
+        return []
+
+    filters = []
+    parameters = []
+    if since is not None:
+        filters.append("window_end >= ?")
+        parameters.append(since)
+    if until is not None:
+        filters.append("window_start < ?")
+        parameters.append(until)
+
+    where_clause = f"WHERE {' AND '.join(filters)}" if filters else ""
+    rows = conn.execute(
+        f"""SELECT session_id, summary_id, created_at, window_start, window_end,
+                   summary, active_task, event_count
+            FROM sessions
+            {where_clause}
+            ORDER BY window_end DESC, created_at DESC, summary_id DESC
+            LIMIT ? OFFSET ?""",
+        (*parameters, limit, offset),
+    ).fetchall()
+    return [
+        {
+            "session_id": row[0],
+            "summary_id": row[1],
+            "created_at": row[2],
+            "window_start": row[3],
+            "window_end": row[4],
+            "summary": row[5],
+            "active_task": row[6],
+            "event_count": row[7],
+        }
+        for row in rows
+    ]
+
+
 def get_summaries(since: float) -> list[dict]:
     rows = conn.execute(
         """SELECT session_id, summary_id, created_at,

--- a/tests/test_timeline_sessions.py
+++ b/tests/test_timeline_sessions.py
@@ -1,0 +1,123 @@
+"""Regression tests for the timeline session listing API."""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from uuid import uuid4
+
+os.environ.setdefault("CLIPPY_DATA_DIR", tempfile.mkdtemp(prefix="clippy-tests-"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+
+from api_server import app
+from core.storage import conn, store_summary
+
+
+class TimelineSessionsTests(unittest.TestCase):
+    """Verify the paginated session-listing contract exposed to the timeline."""
+
+    def setUp(self):
+        self.client = TestClient(app)
+        self.summary_id_prefix = f"timeline-sessions-{uuid4().hex}"
+
+    def tearDown(self):
+        self.client.close()
+        conn.execute(
+            "DELETE FROM sessions WHERE summary_id LIKE ?",
+            (f"{self.summary_id_prefix}%",),
+        )
+        conn.commit()
+
+    def _store_session(
+        self,
+        label: str,
+        window_start: float,
+        window_end: float,
+        created_at: float,
+    ) -> str:
+        summary_id = f"{self.summary_id_prefix}-{label}"
+        store_summary(
+            {
+                "session_id": f"session-{summary_id}",
+                "summary_id": summary_id,
+                "created_at": created_at,
+                "window_start": window_start,
+                "window_end": window_end,
+                "summary": f"Summary for {label}",
+                "active_task": f"Task for {label}",
+                "event_count": 3,
+            },
+            embedding=[0.25, 0.75],
+        )
+        return summary_id
+
+    def test_endpoint_returns_newest_sessions_with_pagination_without_embeddings(self):
+        oldest_id = self._store_session("oldest", 10, 20, 21)
+        middle_id = self._store_session("middle", 30, 40, 41)
+        newest_id = self._store_session("newest", 50, 60, 61)
+
+        first_response = self.client.get(
+            "/timeline/sessions",
+            params={"limit": 2, "offset": 0},
+        )
+        second_response = self.client.get(
+            "/timeline/sessions",
+            params={"limit": 2, "offset": 2},
+        )
+
+        self.assertEqual(first_response.status_code, 200)
+        self.assertEqual(second_response.status_code, 200)
+        first_page = first_response.json()
+        second_page = second_response.json()
+        self.assertEqual(first_page["limit"], 2)
+        self.assertEqual(first_page["offset"], 0)
+        self.assertEqual(
+            [session["summary_id"] for session in first_page["sessions"]],
+            [newest_id, middle_id],
+        )
+        self.assertEqual(
+            [session["summary_id"] for session in second_page["sessions"]],
+            [oldest_id],
+        )
+        for session in first_page["sessions"]:
+            self.assertNotIn("summary_embedding", session)
+            self.assertEqual(session["event_count"], 3)
+
+    def test_endpoint_filters_sessions_by_overlapping_time_window(self):
+        before_id = self._store_session("before", 10, 20, 21)
+        overlapping_id = self._store_session("overlapping", 90, 110, 111)
+        after_id = self._store_session("after", 200, 220, 221)
+
+        http_response = self.client.get(
+            "/timeline/sessions",
+            params={"since": 100, "until": 200, "limit": 40, "offset": 0},
+        )
+
+        self.assertEqual(http_response.status_code, 200)
+        response = http_response.json()
+        self.assertEqual(
+            [session["summary_id"] for session in response["sessions"]],
+            [overlapping_id],
+        )
+        self.assertNotIn(before_id, [session["summary_id"] for session in response["sessions"]])
+        self.assertNotIn(after_id, [session["summary_id"] for session in response["sessions"]])
+
+    def test_endpoint_returns_an_empty_page_when_no_sessions_match(self):
+        http_response = self.client.get(
+            "/timeline/sessions",
+            params={"since": 0, "until": 1, "limit": 40, "offset": 0},
+        )
+
+        self.assertEqual(http_response.status_code, 200)
+        self.assertEqual(
+            http_response.json(),
+            {"sessions": [], "limit": 40, "offset": 0},
+        )
+
+    def test_endpoint_rejects_invalid_pagination(self):
+        response = self.client.get("/timeline/sessions", params={"limit": 0})
+
+        self.assertEqual(response.status_code, 422)


### PR DESCRIPTION
Closes #50

## What problem does this solve?

The API exposes screenshots and conversations, but it does not provide a paginated session listing for future timeline UI work.

## What changed?

- Added `GET /timeline/sessions`.
- Added `limit`, `offset`, `since`, and `until` query parameters.
- Returns session IDs, time windows, summary text, active task, and `event_count`.
- Orders sessions by the most recently completed time window.
- Excludes `summary_embedding` from the response.
- Added HTTP regression coverage for pagination, temporal filters, empty results, response shape, and invalid pagination.

## How was it tested?

- `python -m unittest discover -s tests -p test_timeline_sessions.py` — passed (4 tests).
- `ruff check core/storage.py tests/test_timeline_sessions.py` — passed.
- Manual HTTP verification with Uvicorn and `Invoke-WebRequest` — returned HTTP 200 with the expected JSON contract.
- Tested with a clean temporary database.
- `python -m unittest discover -s tests` — 79/80 passed; the only failure is an existing OCR regression reproduced on the current `main`.
- `python test_installation.py` — imports, local embeddings, and database checks passed; the machine does not have the optional local `qwen3:8b` model installed.

## Scope

No Electron UI, database schema changes, tables, indexes, dependencies, or delete-session endpoint were added.